### PR TITLE
Settings - Duration Multiplier fix for floating-point values

### DIFF
--- a/src/Settings.xaml
+++ b/src/Settings.xaml
@@ -101,13 +101,13 @@
                         </Grid.RowDefinitions>
                         <TextBlock Text="Spawn Multiplier"  VerticalAlignment="Center"  FontWeight="Bold" Grid.Column="0" Grid.Row="0"/>
                         <TextBox x:Name="RespawnMultiplier_Value" MinWidth="60" TextChanged="NumberValue_FieldChanged" Grid.Column="2" Grid.Row="0" 
-                            Text="{Binding SpawnRateMultiplier}" PreviewTextInput="Threshold_Value_PreviewTextInput" Margin="0,2,0,0"/>
+                            Text="{Binding SpawnRateMultiplier}" PreviewTextInput="DecimalValue_PreviewTextInput" Margin="0,2,0,0"/>
                         <TextBlock Text="Beneficial Spell Duration Mult"  VerticalAlignment="Center"  FontWeight="Bold" Grid.Column="0" Grid.Row="1"/>
                         <TextBox x:Name="BeneSpellDurationMultiplier_Value" MinWidth="60" TextChanged="NumberValue_FieldChanged" Grid.Column="2" Grid.Row="1" 
-                            Text="{Binding BeneficialSpellDurationMultiplier}" PreviewTextInput="Threshold_Value_PreviewTextInput" Margin="0,2,0,0"/>
+                            Text="{Binding BeneficialSpellDurationMultiplier}" PreviewTextInput="DecimalValue_PreviewTextInput" Margin="0,2,0,0"/>
                         <TextBlock Text="Detrimental Spell Duration Mult"  VerticalAlignment="Center"  FontWeight="Bold" Grid.Column="0" Grid.Row="2"/>
                         <TextBox x:Name="DetrSpellDurationMultiplier_Value" MinWidth="60" TextChanged="NumberValue_FieldChanged" Grid.Column="2" Grid.Row="2" 
-                            Text="{Binding DetrimentalSpellDurationMultiplier}" PreviewTextInput="Threshold_Value_PreviewTextInput" Margin="0,2,0,0"/>
+                            Text="{Binding DetrimentalSpellDurationMultiplier}" PreviewTextInput="DecimalValue_PreviewTextInput" Margin="0,2,0,0"/>
 
                     </Grid>
                     

--- a/src/Settings.xaml.cs
+++ b/src/Settings.xaml.cs
@@ -1338,6 +1338,18 @@ namespace EQTool
 			e.Handled = regex.IsMatch(e.Text);
         }
 
+		private void DecimalValue_PreviewTextInput(object sender, System.Windows.Input.TextCompositionEventArgs e)
+		{
+			var textBox = sender as System.Windows.Controls.TextBox;
+			if (e.Text == "." && !textBox.Text.Contains("."))
+			{
+				e.Handled = false;
+				return;
+			}
+			Regex regex = new Regex("[^0-9]+");
+			e.Handled = regex.IsMatch(e.Text);
+		}
+
 		private void NumberValue_FieldChanged(object sender, TextChangedEventArgs e)
 		{
 			if(sender == RespawnMultiplier_Value && double.TryParse(RespawnMultiplier_Value.Text, out double spawnMulti))


### PR DESCRIPTION
Settings dialog now allows for floating-point values in the Duration Multiplier textboxes for "Spawn Multiplier", "Beneficial Spell Duration Mult", and "Detrimental Spell Duration Mult".

This allows for the User to specify values in particular that represent Beneficial Spell Duration extensions from AAs and Item Focus Effects.